### PR TITLE
Increase character limit for filename suggestions (issue #27)

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -116,7 +116,7 @@ getTopLines file = do
 
 
 lengthCheck :: Text -> Bool
-lengthCheck t = T.length t >= 3 && T.length t <= 64
+lengthCheck t = T.length t >= 3 && T.length t <= 251 -- maximum filename length on most Unix FSs (255) - extension (.pdf, 4) = 251
 
 
 boolToMaybe :: (a -> Bool) -> a -> Maybe a


### PR DESCRIPTION
Paper names may be longer than the previous limit of 64 characters, so
increased limit to longest possible filename on most modern filesystems.