### PR TITLE
Launch viewer in background and discard output

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -29,6 +29,7 @@ import qualified Path
 import qualified Path.IO as Path
 import qualified System.FilePath as F
 import qualified System.Process as P
+import qualified GHC.IO.Handle.Types as IOHT
 import           System.Directory (findExecutable)
 import qualified Text.PDF.Info as PDFI
 
@@ -188,6 +189,7 @@ openFile file = do
                 else pure ()
 
 
-tryOpenWith :: Path Abs File -> FilePath -> IO (P.ProcessHandle)
-tryOpenWith file cmd =
-    P.runCommand (cmd ++ " " ++ Path.fromAbsFile file)
+tryOpenWith :: Path Abs File -> FilePath -> IO ()
+tryOpenWith file cmd = do
+    _ <- P.createProcess (P.proc cmd [Path.fromAbsFile file]){ P.std_out = P.NoStream, P.std_err = P.NoStream }
+    return ()

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -175,18 +175,18 @@ fileFile conf newFileName file = do
 
 openFile :: Path Abs File -> IO ()
 openFile file = do
-    xdgOpenPresent <- findExecutable "xdg-open"
-    if Maybe.isJust xdgOpenPresent
-        then do
-            tryOpenWith file "xdg-open"
-            pure ()
+    tryViewers ["xdg-open", "open"] file
+
+
+tryViewers :: [[Char]] -> Path Abs File -> IO ()
+tryViewers [] file = do return ()
+tryViewers (e:es) file = do
+    v <- findExecutable e
+    if Maybe.isNothing v
+        then tryViewers es file
         else do
-            openPresent <- findExecutable "open"
-            if Maybe.isJust openPresent
-                then do
-                    tryOpenWith file "open"
-                    pure ()
-                else pure ()
+            tryOpenWith file e
+            return ()
 
 
 tryOpenWith :: Path Abs File -> FilePath -> IO ()


### PR DESCRIPTION
With this, the user interface no longer becomes unresponsive when the external viewer is blocking (#26), and the interface is no longer garbled by output from the external viewer (#25).

Previously, paperboy checked the output from a viewer launch attempt to detect if the launch failed (due to errors or because the viewer command wasn't available on the system).

This change sacrifices the error detection; it only checks (separately, beforehand) whether the viewer command exists. This should be sufficient, as any launch problems that would cause an error return code (non-existent file, insufficient permissions, insufficient memory, …) would affect all viewers anyway.