### PR TITLE
Added shortcut for changing library sort order

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -8,6 +8,9 @@ module Lib
     , fileNameSuggestions
     , openFile
     , sortFileInfoByDate
+    , sortFileInfoByName
+    , sortFileInfo
+    , SortType(..)
     ) where
 
 import           Config (Config)
@@ -48,9 +51,22 @@ listFiles path = do
     else pure []
 
 
+data SortType = SortDate | SortName
+
+
 sortFileInfoByDate :: [FileInfo] -> [FileInfo]
 sortFileInfoByDate fileInfos =
     reverse $ sortWith _modTime fileInfos
+
+
+sortFileInfoByName :: [FileInfo] -> [FileInfo]
+sortFileInfoByName fileInfos =
+    reverse $ sortWith _fileName fileInfos
+
+
+sortFileInfo :: SortType -> [FileInfo] -> [FileInfo]
+sortFileInfo SortDate = sortFileInfoByDate
+sortFileInfo SortName = sortFileInfoByName
 
 
 getFileInfo :: Path Abs File -> IO FileInfo

--- a/src/UI.hs
+++ b/src/UI.hs
@@ -269,6 +269,11 @@ handleEvent s (VtyEvent e) =
             continue $ s
                 & focusRing .~ inboxFocus
                 & help .~ Nothing
+
+        cycleLibSortAndReferesh = do
+            cycleState <- liftIO $ cycleLibSort s
+            newState <- liftIO $ refreshFiles cycleState
+            continue $ newState
     in
     case (focus, e) of
         (_, V.EvKey (V.KChar 'c') [V.MCtrl])            -> halt s
@@ -301,10 +306,8 @@ handleEvent s (VtyEvent e) =
         (Just Library, V.EvKey (V.KChar 'h') []) -> openHelp
         (Just Help,    V.EvKey (V.KChar 'h') []) -> backToMain
 
-        (_, V.EvKey (V.KChar 'l') []) -> do
-            cycleState <- liftIO $ cycleLibSort s
-            newState <- liftIO $ refreshFiles cycleState
-            continue $ newState
+        (Just Inbox, V.EvKey (V.KChar 'l') [])   -> cycleLibSortAndReferesh
+        (Just Library, V.EvKey (V.KChar 'l') []) -> cycleLibSortAndReferesh
         
         _ ->
             case (focus, s ^. fileImport) of


### PR DESCRIPTION
This PR adds a shortcut key (L) for changing the sort order of library between time and lexical