### PR TITLE
apply toLower before titlecase

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -142,6 +142,9 @@ sanitize text =
         & T.unwords . T.words
         & T.unpack
         & filter validChars
+        & T.pack
+        & T.toLower
+        & T.unpack
         & titlecase
         & T.pack
 


### PR DESCRIPTION
Addresses #53 .

I have applied `toLower` before `titlecase`.

There may be cleaner ways to do this, but I had to `pack` and `unpack` for the data to be `Text`, for `toLower`. 
```
& T.pack
& T.toLower
& T.unpack
```

A potential issue may be with `toLower` changing the string. From the [source](https://hackage.haskell.org/package/text-2.0/docs/src/Data.Text.html#toLower),

> The result string may be longer than the input string.  For
instance, \"&#x130;\" (Latin capital letter I with dot above,
U+0130) maps to the sequence \"i\" (Latin small letter i, U+0069)
followed by \" &#x307;\" (combining dot above, U+0307).